### PR TITLE
accepts ::1 for localhost REMOTE_ADDR

### DIFF
--- a/lib/ip_restriction/ip_loader.rb
+++ b/lib/ip_restriction/ip_loader.rb
@@ -2,7 +2,7 @@ require 'yaml'
 
 module IpRestriction
   class IpLoader
-    DEFAULT_IPS = ['127.0.0.1']
+    DEFAULT_IPS = ['127.0.0.1', '::1']
 
     attr_reader :file_path
 


### PR DESCRIPTION
When i using puma server, the REMOTE_ADDR returns '::1' ipv6 localhost
